### PR TITLE
Add GPT utilities and endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ This sample project is a minimal FastAPI application that can be deployed with U
    pip install -r requirements.txt
    ```
 
-2. Run the app locally:
+2. Configure your OpenAI API key:
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+3. Run the app locally:
    ```bash
    uvicorn main:app --reload
    ```
@@ -28,3 +33,8 @@ Deploy using your preferred method (e.g., `gcloud app deploy`).
 ## F:Core Platform Documentation
 
 Un aperçu de l'architecture et des objectifs du projet est disponible dans [docs/architecture.md](docs/architecture.md).
+
+## API Endpoints
+
+- `POST /summarize` – envoie un texte et reçoit un résumé en deux phrases généré par GPT‑4o-mini.
+- `POST /named-entities` – renvoie les entités nommées détectées sous forme de tableau JSON `{text, label}`.

--- a/gpt_utils.py
+++ b/gpt_utils.py
@@ -1,0 +1,18 @@
+import os
+import openai
+
+MODEL_NAME = "gpt-4o-mini"
+_api_key = os.getenv("OPENAI_API_KEY")
+
+if not _api_key:
+    raise EnvironmentError("OPENAI_API_KEY environment variable is not set")
+
+_client = openai.OpenAI(api_key=_api_key)
+
+def chat(messages, model: str = MODEL_NAME) -> str:
+    """Send a list of messages to the OpenAI chat completion API."""
+    response = _client.chat.completions.create(
+        model=model,
+        messages=messages,
+    )
+    return response.choices[0].message.content.strip()

--- a/main.py
+++ b/main.py
@@ -1,12 +1,51 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+import json
+
+from gpt_utils import chat
 
 app = FastAPI()
+
 @app.get("/")
 async def index():
     return {"message": "hello, world"}
+
+
+class TextRequest(BaseModel):
+    text: str
+
+
+@app.post("/summarize")
+async def summarize(req: TextRequest):
+    messages = [
+        {"role": "system", "content": "Vous êtes un assistant."},
+        {
+            "role": "user",
+            "content": f"Résume le texte en 2 phrases : {req.text}",
+        },
+    ]
+    summary = chat(messages)
+    return {"summary": summary}
+
+
+@app.post("/named-entities")
+async def named_entities(req: TextRequest):
+    instruction = (
+        "Extract the named entities from the text as JSON array of objects with"
+        " 'text' and 'label'."
+    )
+    messages = [
+        {"role": "system", "content": instruction},
+        {"role": "user", "content": req.text},
+    ]
+    data = chat(messages)
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError:
+        return {"raw": data}
+
 
 if __name__ == "__main__":
     # Dev only: run "python main.py" and open http://localhost:8080
     import uvicorn
     uvicorn.run(app, host="localhost", port=8080)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ fastapi==0.110.0
 
 # https://pypi.org/project/uvicorn/
 uvicorn==0.29.0
+
+openai>=1.0.0


### PR DESCRIPTION
## Summary
- add dependency on `openai`
- implement `gpt_utils.py` for simple OpenAI chat access
- expand `main.py` with `/summarize` and `/named-entities` endpoints
- document setup of OpenAI API key and endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847d7116a24832ebe975384532f1f2c