### PR TITLE
Add LangChain agent endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This sample project is a minimal FastAPI application that can be deployed with U
    ```
    Then open <http://localhost:8080> in your browser.
 
+The `/agent` endpoint relies on [LangChain](https://python.langchain.com/) and
+requires an OpenAI API key just like the other endpoints.
+
 ## Deployment
 
 The `Procfile` configures Uvicorn for production environments such as Google App Engine:
@@ -38,3 +41,4 @@ Un aperçu de l'architecture et des objectifs du projet est disponible dans [doc
 
 - `POST /summarize` – envoie un texte et reçoit un résumé en deux phrases généré par GPT‑4o-mini.
 - `POST /named-entities` – renvoie les entités nommées détectées sous forme de tableau JSON `{text, label}`.
+- `POST /agent` – exécute un agent LangChain qui combine raisonnement pas à pas et réponse finale.

--- a/agents/langchain_agent.py
+++ b/agents/langchain_agent.py
@@ -1,0 +1,35 @@
+from langchain.chains import LLMChain, SequentialChain
+from langchain.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+
+# Configure the LLM
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+
+# Chain-of-thought reasoning step
+reason_prompt = PromptTemplate(
+    input_variables=["question"],
+    template=(
+        "You are a helpful agent. "
+        "Use step-by-step reasoning to solve the user's question.\n" 
+        "Question: {question}"
+    ),
+)
+reason_chain = LLMChain(llm=llm, prompt=reason_prompt, output_key="reason")
+
+# Final answer step that reacts based on the reasoning
+answer_prompt = PromptTemplate(
+    input_variables=["reason"],
+    template="Provide the final answer based on your reasoning:\n{reason}",
+)
+answer_chain = LLMChain(llm=llm, prompt=answer_prompt, output_key="answer")
+
+# Combine the steps in a sequential chain
+agent_chain = SequentialChain(
+    chains=[reason_chain, answer_chain],
+    input_variables=["question"],
+    output_variables=["answer", "reason"],
+)
+
+def run_agent(question: str) -> dict:
+    """Execute the LangChain agent with the given question."""
+    return agent_chain({"question": question})

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 import json
 
 from gpt_utils import chat
+from agents.langchain_agent import run_agent
 
 app = FastAPI()
 
@@ -13,6 +14,13 @@ async def index():
 
 class TextRequest(BaseModel):
     text: str
+
+
+@app.post("/agent")
+async def agent(req: TextRequest):
+    """Invoke the LangChain sequential agent."""
+    result = run_agent(req.text)
+    return result
 
 
 @app.post("/summarize")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ fastapi==0.110.0
 uvicorn==0.29.0
 
 openai>=1.0.0
+langchain
+langchain-openai


### PR DESCRIPTION
## Summary
- include LangChain packages in requirements
- implement a simple sequential LangChain agent
- expose `/agent` endpoint that runs the agent
- document new endpoint in README

## Testing
- `python -m pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.0)*

------
https://chatgpt.com/codex/tasks/task_e_6847d8b1148c832e9c7b41c5115a7b97