### PR TITLE
Add orchestration API and architecture updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,28 @@ Un aperçu de l'architecture et des objectifs du projet est disponible dans [doc
 - `POST /summarize` – envoie un texte et reçoit un résumé en deux phrases généré par GPT‑4o-mini.
 - `POST /named-entities` – renvoie les entités nommées détectées sous forme de tableau JSON `{text, label}`.
 - `POST /agent` – exécute un agent LangChain qui combine raisonnement pas à pas et réponse finale.
+
+## Orchestration API
+
+Ces routes permettent de gérer les workflows low-code :
+
+- `GET /tools` – liste des tools disponibles.
+- `GET /workflows/{id}` – récupère la configuration d'un workflow.
+- `POST /workflows` – crée un nouveau workflow.
+- `POST /workflows/{id}/run` – lance l'exécution.
+- WebSocket `ws://host/ws/workflows/{runId}/events` – flux en temps réel des logs de la run.
+
+Un client WebSocket peut recevoir les logs ainsi :
+
+```python
+import websockets
+import asyncio
+
+async def watch(run_id):
+    uri = f"ws://localhost:8080/ws/workflows/{run_id}/events"
+    async with websockets.connect(uri) as ws:
+        async for line in ws:
+            print(line)
+
+asyncio.run(watch("run-wf1"))
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,3 +80,20 @@ Réponse :
   "timestamp": "2025-06-10T14:30:00Z"
 }
 ```
+
+## Cha\u00eene de traitement
+
+La configuration cr\u00e9\u00e9e dans le **Frontend Low\u2011Code Builder** est envoy\u00e9e vers l'API \
+qui transmet au **MCP Server / Memory**. Ce dernier orchestre l'ex\u00e9cution en \
+s'appuyant sur les **Agno Core Agents ou LangChain Agents** qui pilotent les \
+tools n\u00e9cessaires.
+
+## Pile technologique recommand\u00e9e
+
+| Couche | Technologies recommand\u00e9es |
+| ------ | ---------------------------- |
+| Frontend Low\u2011Code Builder | React, React Flow |
+| API Backend | FastAPI, Uvicorn |
+| Agents | Agno Core Agents ou LangChain |
+| Stockage/M\u00e9moire | Postgres, Redis, pgvector |
+| D\u00e9ploiement | Google App Engine ou Cloud Run |

--- a/main.py
+++ b/main.py
@@ -4,8 +4,10 @@ import json
 
 from gpt_utils import chat
 from agents.langchain_agent import run_agent
+from orchestrator import router as orchestrator_router
 
 app = FastAPI()
+app.include_router(orchestrator_router)
 
 @app.get("/")
 async def index():

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,43 @@
+from fastapi import APIRouter, WebSocket
+import asyncio
+
+router = APIRouter()
+
+# Dummy in-memory stores for example purposes
+TOOLS = [
+    {"id": "t1", "name": "Sample Tool"},
+]
+
+WORKFLOWS = {}
+
+@router.get("/tools")
+async def list_tools():
+    """Return the registered tools."""
+    return TOOLS
+
+@router.get("/workflows/{workflow_id}")
+async def get_workflow(workflow_id: str):
+    """Return a workflow configuration."""
+    return WORKFLOWS.get(workflow_id, {"id": workflow_id, "steps": []})
+
+@router.post("/workflows")
+async def create_workflow(config: dict):
+    """Create a workflow."""
+    workflow_id = f"wf{len(WORKFLOWS)+1}"
+    WORKFLOWS[workflow_id] = config
+    return {"id": workflow_id}
+
+@router.post("/workflows/{workflow_id}/run")
+async def run_workflow(workflow_id: str):
+    """Start a workflow run and return its run identifier."""
+    run_id = f"run-{workflow_id}"
+    return {"runId": run_id}
+
+@router.websocket("/ws/workflows/{run_id}/events")
+async def workflow_events(websocket: WebSocket, run_id: str):
+    """Yield log lines for a running workflow."""
+    await websocket.accept()
+    for i in range(5):
+        await websocket.send_text(f"{run_id}: log {i+1}")
+        await asyncio.sleep(0.5)
+    await websocket.close()


### PR DESCRIPTION
## Summary
- extend architecture document with chain description and tech stack table
- add an orchestrator router providing workflow management endpoints
- mount the orchestrator API in the FastAPI app
- document the orchestration API and WebSocket usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847dc20bbbc832e901b1f798191074a