### PR TITLE
Expose summarize and NER tools through orchestration API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,16 @@ Un aperçu de l'architecture et des objectifs du projet est disponible dans [doc
 - `POST /summarize` – envoie un texte et reçoit un résumé en deux phrases généré par GPT‑4o-mini.
 - `POST /named-entities` – renvoie les entités nommées détectées sous forme de tableau JSON `{text, label}`.
 - `POST /agent` – exécute un agent LangChain qui combine raisonnement pas à pas et réponse finale.
+  Les deux premières opérations sont également référencées via la route
+  `GET /tools`.
 
 ## Orchestration API
 
 Ces routes permettent de gérer les workflows low-code :
 
-- `GET /tools` – liste des tools disponibles.
+- `GET /tools` – liste des tools disponibles. Les entrées
+  `summarize` et `named-entities` renvoient respectivement vers les
+  routes `POST /summarize` et `POST /named-entities`.
 - `GET /workflows/{id}` – récupère la configuration d'un workflow.
 - `POST /workflows` – crée un nouveau workflow.
 - `POST /workflows/{id}/run` – lance l'exécution.

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -4,8 +4,14 @@ import asyncio
 router = APIRouter()
 
 # Dummy in-memory stores for example purposes
+# Each tool advertises the POST endpoint that executes it.
 TOOLS = [
-    {"id": "t1", "name": "Sample Tool"},
+    {"id": "summarize", "name": "Summarize text", "endpoint": "/summarize"},
+    {
+        "id": "named-entities",
+        "name": "Extract named entities",
+        "endpoint": "/named-entities",
+    },
 ]
 
 WORKFLOWS = {}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,13 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_list_tools_includes_registered_entries():
+    response = client.get("/tools")
+    assert response.status_code == 200
+    tools = response.json()
+    ids = {tool["id"] for tool in tools}
+    assert {"summarize", "named-entities"} <= ids
+


### PR DESCRIPTION
## Summary
- register `summarize` and `named-entities` tools in the orchestrator
- document their availability in `/tools`
- add unit test checking the `/tools` endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847de9265a8832ebd6426efd89b121e