### PR TITLE
Update FastAPI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # https://pypi.org/project/fastapi/
-fastapi==0.110.0
+fastapi[all]==0.110.0
 
 # https://pypi.org/project/uvicorn/
 uvicorn==0.29.0


### PR DESCRIPTION
## Summary
- use `fastapi[all]==0.110.0` in requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847e45db3fc832eaecca3a15c105ab5