### PR TITLE
Add tool schema endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Ces routes permettent de gérer les workflows low-code :
 - `GET /tools` – liste des tools disponibles. Les entrées
   `summarize` et `named-entities` renvoient respectivement vers les
   routes `POST /summarize` et `POST /named-entities`.
+- `GET /tools/{id}/schema` – renvoie le JSON Schema associé à un tool.
 - `GET /workflows/{id}` – récupère la configuration d'un workflow.
 - `POST /workflows` – crée un nouveau workflow.
 - `POST /workflows/{id}/run` – lance l'exécution.

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, WebSocket
+from fastapi import APIRouter, WebSocket, HTTPException
 import asyncio
 
 router = APIRouter()
@@ -14,12 +14,42 @@ TOOLS = [
     },
 ]
 
+# Basic JSON Schemas describing the configuration for each tool.
+# These would normally be defined alongside the tool implementation.
+TOOL_SCHEMAS = {
+    "summarize": {
+        "title": "Summarize text",
+        "type": "object",
+        "properties": {
+            "text": {"title": "Text", "type": "string"},
+        },
+        "required": ["text"],
+    },
+    "named-entities": {
+        "title": "Extract named entities",
+        "type": "object",
+        "properties": {
+            "text": {"title": "Text", "type": "string"},
+        },
+        "required": ["text"],
+    },
+}
+
 WORKFLOWS = {}
 
 @router.get("/tools")
 async def list_tools():
     """Return the registered tools."""
     return TOOLS
+
+
+@router.get("/tools/{tool_id}/schema")
+async def get_tool_schema(tool_id: str):
+    """Return the JSON Schema for a tool."""
+    schema = TOOL_SCHEMAS.get(tool_id)
+    if not schema:
+        raise HTTPException(status_code=404, detail="Tool not found")
+    return schema
 
 @router.get("/workflows/{workflow_id}")
 async def get_workflow(workflow_id: str):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,3 +11,11 @@ def test_list_tools_includes_registered_entries():
     ids = {tool["id"] for tool in tools}
     assert {"summarize", "named-entities"} <= ids
 
+
+@pytest.mark.parametrize("tool_id", ["summarize", "named-entities"])
+def test_tool_schema_endpoint(tool_id):
+    response = client.get(f"/tools/{tool_id}/schema")
+    assert response.status_code == 200
+    schema = response.json()
+    assert schema["type"] == "object"
+


### PR DESCRIPTION
## Summary
- expose JSON schema for each tool under `/tools/{id}/schema`
- include simple schemas for built‑in tools
- document the new route
- test the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847e5a3f990832eb3def42f03fc0706