### PR TITLE
Add DevStudio Next.js skeleton

### DIFF
--- a/devstudio-next/components/DevStudio.js
+++ b/devstudio-next/components/DevStudio.js
@@ -1,0 +1,21 @@
+import dynamic from 'next/dynamic';
+import FileTreePanel from './FileTreePanel';
+import TestInputPanel from './TestInputPanel';
+import LogsPanel from './LogsPanel';
+
+const MonacoEditor = dynamic(() => import('./MonacoEditor'), { ssr: false });
+
+export default function DevStudio() {
+  return (
+    <div style={{ display: 'flex', height: '100vh' }}>
+      <div style={{ flex: 1 }}>
+        <FileTreePanel />
+      </div>
+      <div style={{ flex: 2, display: 'flex', flexDirection: 'column' }}>
+        <MonacoEditor />
+        <TestInputPanel />
+        <LogsPanel />
+      </div>
+    </div>
+  );
+}

--- a/devstudio-next/components/FileTreePanel.js
+++ b/devstudio-next/components/FileTreePanel.js
@@ -1,0 +1,8 @@
+export default function FileTreePanel() {
+  return (
+    <div style={{ padding: '1rem', borderRight: '1px solid #ccc' }}>
+      <h3>File Tree</h3>
+      {/* Placeholder for file tree */}
+    </div>
+  );
+}

--- a/devstudio-next/components/LogsPanel.js
+++ b/devstudio-next/components/LogsPanel.js
@@ -1,0 +1,8 @@
+export default function LogsPanel() {
+  return (
+    <div style={{ padding: '1rem', borderTop: '1px solid #ccc' }}>
+      <h3>Logs</h3>
+      {/* Real-time log output */}
+    </div>
+  );
+}

--- a/devstudio-next/components/MonacoEditor.js
+++ b/devstudio-next/components/MonacoEditor.js
@@ -1,0 +1,22 @@
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+
+const Editor = dynamic(
+  () => import('@monaco-editor/react').then(mod => mod.default),
+  { ssr: false }
+);
+
+export default function MonacoEditor() {
+  const [code, setCode] = useState('// Write code here');
+  return (
+    <div style={{ flex: 1 }}>
+      <Editor
+        height="50vh"
+        defaultLanguage="javascript"
+        value={code}
+        onChange={value => setCode(value)}
+        options={{ minimap: { enabled: false } }}
+      />
+    </div>
+  );
+}

--- a/devstudio-next/components/TestInputPanel.js
+++ b/devstudio-next/components/TestInputPanel.js
@@ -1,0 +1,8 @@
+export default function TestInputPanel() {
+  return (
+    <div style={{ padding: '1rem', borderTop: '1px solid #ccc' }}>
+      <h3>Test Input</h3>
+      {/* Add fields to run tests */}
+    </div>
+  );
+}

--- a/devstudio-next/next.config.js
+++ b/devstudio-next/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+};

--- a/devstudio-next/package.json
+++ b/devstudio-next/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "devstudio-next",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@monaco-editor/react": "latest"
+  }
+}

--- a/devstudio-next/pages/index.js
+++ b/devstudio-next/pages/index.js
@@ -1,0 +1,13 @@
+import Head from 'next/head';
+import DevStudio from '../components/DevStudio';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>DevStudio</title>
+      </Head>
+      <DevStudio />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a standalone Next.js app under `devstudio-next`
- implement `DevStudio` with MonacoEditor, FileTreePanel, TestInputPanel, and LogsPanel components
- include initial page rendering the DevStudio component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6847ed1b0480832e9ea06ef0bd3517cf