### PR TITLE
Add MCP server endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This sample project is a minimal FastAPI application that can be deployed with U
 1. Install dependencies:
    ```bash
    pip install -r requirements.txt
+   # Required for NER
+   python -m spacy download en_core_web_sm
    ```
 
 2. Run the app locally:
@@ -24,6 +26,16 @@ web: uvicorn main:app --host 0.0.0.0 --port $PORT
 ```
 
 Deploy using your preferred method (e.g., `gcloud app deploy`).
+
+## API Endpoints
+
+- `GET /context` : récupère le contexte stocké en mémoire.
+- `POST /context` : met à jour le contexte pour un `userId` donné.
+- `POST /summary` : renvoie un résumé court du texte fourni (premières phrases).
+- `POST /ner` : extrait les entités nommées du texte via spaCy.
+
+Ces endpoints illustrent la mise en place d'un **MCP server** et de quelques
+tools du module **F:Insight** (résumé et NER).
 
 ## F:Core Platform Documentation
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,55 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import spacy
+import re
+
+nlp = None
+try:
+    nlp = spacy.load("en_core_web_sm")
+except OSError:
+    # spaCy model is missing; inform user
+    nlp = None
+
+class TextPayload(BaseModel):
+    text: str
+
+class ContextPayload(BaseModel):
+    userId: str
+    data: dict
 
 app = FastAPI()
+
+_contexts = {}
 @app.get("/")
 async def index():
     return {"message": "hello, world"}
+
+
+@app.get("/context")
+async def get_context(userId: str):
+    return _contexts.get(userId, {})
+
+
+@app.post("/context")
+async def set_context(payload: ContextPayload):
+    _contexts[payload.userId] = payload.data
+    return {"status": "ok"}
+
+
+@app.post("/summary")
+async def summarize(payload: TextPayload):
+    sentences = re.split(r"(?<=[.!?]) +", payload.text.strip())
+    summary = " ".join(sentences[:2])
+    return {"summary": summary}
+
+
+@app.post("/ner")
+async def named_entities(payload: TextPayload):
+    if nlp is None:
+        raise HTTPException(status_code=500, detail="spaCy model 'en_core_web_sm' not installed")
+    doc = nlp(payload.text)
+    entities = [{"text": ent.text, "label": ent.label_} for ent in doc.ents]
+    return {"entities": entities}
 
 if __name__ == "__main__":
     # Dev only: run "python main.py" and open http://localhost:8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi==0.110.0
 
 # https://pypi.org/project/uvicorn/
 uvicorn==0.29.0
+spacy==3.7.2


### PR DESCRIPTION
## Summary
- add spaCy dependency
- document installing spaCy model and new endpoints
- implement /context, /summary and /ner endpoints in FastAPI

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847d549b994832e96e7c0e14355636d